### PR TITLE
Revoke all user messages when kick

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -37,10 +37,11 @@ bot.command(
     for (const chat of chats) {
       console.log(`Banning ${ctx.message.reply_to_message.from.id} in ${chat}`)
       try {
-        await ctx.telegram.kickChatMember(
-          chat,
-          ctx.message.reply_to_message.from.id
-        )
+        await ctx.telegram.callApi('kickChatMember', {
+          chat_id: chat,
+          user_id: ctx.message.reply_to_message.from.id,
+          revoke_messages: true,
+        })
       } catch (err) {
         ctx.reply(`Ошибка: ${err.message || err}`)
       }


### PR DESCRIPTION
Telegraf's `kickChatMembers` method doesn't provide `revoke_messages` param so we get around using `callApi`.